### PR TITLE
Fix for missing last line for IFS

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ fi
 
 declare -A failed
 i=0
-while IFS= read -r path
+while IFS= read -r path || [ -n "$path" ]
 do
     docName="${path%"${path##*[!/]}"}"
     docName="${docName##*/}"


### PR DESCRIPTION
As stated here: https://stackoverflow.com/a/31398490
And here: https://stackoverflow.com/a/31397497

The IFS does not read the last line of the pathToBuild file, except is a newline. This should do the trick.